### PR TITLE
Extrinsic base weight update

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -54,7 +54,7 @@ pub use pallet_faucet;
 
 /// Import the template pallet.
 pub use pallet_template;
-use pallet_transaction_multi_payment::MultiCurrencyAdapter;
+use pallet_transaction_multi_payment::{MultiCurrencyAdapter, WeightInfo};
 
 /// An index to a block.
 pub type BlockNumber = u32;
@@ -142,8 +142,8 @@ parameter_types! {
 	pub const MaximumBlockLength: u32 = 5 * 1024 * 1024;
 	pub const Version: RuntimeVersion = VERSION;
 
-	pub const ExtrinsicPaymentExtraWeight: Weight = 307_000_000; //TODO: we need somehow to integrate total swap currency weight here!
-	pub const ExtrinsicBaseWeight: Weight = frame_support::weights::constants::ExtrinsicBaseWeight::get() + ExtrinsicPaymentExtraWeight::get();
+	pub ExtrinsicPaymentExtraWeight: Weight =  <Runtime as pallet_transaction_multi_payment::Trait>::WeightInfo::swap_currency();
+	pub ExtrinsicBaseWeight: Weight = frame_support::weights::constants::ExtrinsicBaseWeight::get() + ExtrinsicPaymentExtraWeight::get();
 }
 
 // Configure FRAME pallets to include in runtime.


### PR DESCRIPTION
This was actually not that bad as i originally expected. 

Extrinsic base weight includes payment swap extra weight which is now taken from the swap currency benchmarked weight.